### PR TITLE
Task 1-2: 타입 정의 및 상수 모듈 구현 완료

### DIFF
--- a/EXECUTION.md
+++ b/EXECUTION.md
@@ -119,59 +119,59 @@
 ### Task 1-2: 타입 정의 및 상수 모듈 구현
 **분류**: 백엔드/타입정의 | **의존성**: Task 1-1 | **브랜치**: `task/1-2-types-constants`
 
-- [ ] 알라딘 API 응답 인터페이스 정의 (src/types.ts)
-  - [ ] ItemSearch 응답 타입 (검색 결과, totalResults, startIndex, itemsPerPage)
-  - [ ] ItemLookUp 응답 타입 (상세 정보, item 배열)
-  - [ ] ItemList 응답 타입 (베스트셀러/신간/추천 등)
-  - [ ] 공통 item 객체 타입 (title, author, publisher, isbn, cover 등)
-  - [ ] subInfo 객체 타입 (부가 정보)
-- [ ] 검색 파라미터 타입 정의
-  - [ ] Query, QueryType 타입 (Title, Author, Publisher, Keyword)
-  - [ ] SearchTarget 타입 (Book, Foreign, eBook, Music, DVD)
-  - [ ] Sort 옵션 (Accuracy, PublishTime, Title, SalesPoint, CustomerRating)
-  - [ ] Cover 타입 (None, Small, MidBig, Big, None)
-  - [ ] Output 타입 (XML, JS)
-  - [ ] Version 타입 (20070901 등)
-  - [ ] OptResult 타입 (authors, fulldescription, Toc, Story, categoryIdList)
-  - [ ] 페이지네이션 파라미터 (Start, MaxResults)
-- [ ] 도서 정보 타입 정의
-  - [ ] 기본 도서 정보 (제목, 저자, 출판사, ISBN)
-  - [ ] 추가 정보 (가격, 할인율, 출간일, 설명)
-  - [ ] 이미지 정보 (표지, 목차)
-- [ ] 베스트셀러/신간 리스트 타입 정의
-  - [ ] CategoryId 타입 정의 (aladin_Category_CID_20210927.csv 기반)
-  - [ ] 카테고리 계층 구조 타입 (1Depth~5Depth)
-  - [ ] 카테고리 매핑 인터페이스 (CID, 카테고리명, 몰 구분)
-  - [ ] QueryType 타입 (Bestseller, NewBook, NewSpecial, EditorChoice 등)
-  - [ ] 기간 타입 정의 (Daily, Weekly, Monthly)
-- [ ] MCP 도구별 입력/출력 타입 정의
-  - [ ] MCP 도구 스키마 인터페이스
-  - [ ] 입력 파라미터 검증 타입
-  - [ ] 도구 응답 포맷 타입
-  - [ ] MCP 서버 메타데이터 타입
-- [ ] 에러 응답 타입 정의
-  - [ ] errorCode, errorMessage 구조
-  - [ ] TTB 키 관련 에러 타입
-  - [ ] API 호출 한도 초과 에러 타입
-  - [ ] MCP 프로토콜 에러 타입
-  - [ ] 네트워크 에러 타입
-- [ ] API 관련 상수 정의 (src/constants/api.ts)
-  - [ ] API 기본 URL (http://www.aladin.co.kr/ttb/api/)
-  - [ ] 엔드포인트 (ItemSearch.aspx, ItemLookUp.aspx, ItemList.aspx)
-  - [ ] SearchTarget 상수 (Book, Foreign, eBook, Music, DVD)
-  - [ ] Sort 옵션 상수 (Accuracy, PublishTime, Title 등)
-  - [ ] Cover 크기 상수 (None, Small, MidBig, Big)
-  - [ ] 기본 파라미터 값 (Version: 20070901, Output: JS 등)
-  - [ ] 에러 메시지 상수
-  - [ ] MCP 도구 스키마 상수
-- [ ] 카테고리 관련 상수/유틸리티 (src/constants/categories.ts)
-  - [ ] CSV 파일 파싱 유틸리티
-  - [ ] 카테고리 매핑 테이블 생성
-  - [ ] 카테고리 검색/조회 유틸리티
-  - [ ] 계층별 카테고리 필터링 기능
-- [ ] Git 작업 완료
-  - [ ] 모든 변경사항 커밋 (`feat: 타입 정의 및 상수 모듈 구현`)
-  - [ ] PR 생성 (`Task 1-2: 타입 정의 및 상수 모듈 완료`)
+- [x] 알라딘 API 응답 인터페이스 정의 (src/types.ts)
+  - [x] ItemSearch 응답 타입 (검색 결과, totalResults, startIndex, itemsPerPage)
+  - [x] ItemLookUp 응답 타입 (상세 정보, item 배열)
+  - [x] ItemList 응답 타입 (베스트셀러/신간/추천 등)
+  - [x] 공통 item 객체 타입 (title, author, publisher, isbn, cover 등)
+  - [x] subInfo 객체 타입 (부가 정보)
+- [x] 검색 파라미터 타입 정의
+  - [x] Query, QueryType 타입 (Title, Author, Publisher, Keyword)
+  - [x] SearchTarget 타입 (Book, Foreign, eBook, Music, DVD)
+  - [x] Sort 옵션 (Accuracy, PublishTime, Title, SalesPoint, CustomerRating)
+  - [x] Cover 타입 (None, Small, MidBig, Big, None)
+  - [x] Output 타입 (XML, JS)
+  - [x] Version 타입 (20070901 등)
+  - [x] OptResult 타입 (authors, fulldescription, Toc, Story, categoryIdList)
+  - [x] 페이지네이션 파라미터 (Start, MaxResults)
+- [x] 도서 정보 타입 정의
+  - [x] 기본 도서 정보 (제목, 저자, 출판사, ISBN)
+  - [x] 추가 정보 (가격, 할인율, 출간일, 설명)
+  - [x] 이미지 정보 (표지, 목차)
+- [x] 베스트셀러/신간 리스트 타입 정의
+  - [x] CategoryId 타입 정의 (aladin_Category_CID_20210927.csv 기반)
+  - [x] 카테고리 계층 구조 타입 (1Depth~5Depth)
+  - [x] 카테고리 매핑 인터페이스 (CID, 카테고리명, 몰 구분)
+  - [x] QueryType 타입 (Bestseller, NewBook, NewSpecial, EditorChoice 등)
+  - [x] 기간 타입 정의 (Daily, Weekly, Monthly)
+- [x] MCP 도구별 입력/출력 타입 정의
+  - [x] MCP 도구 스키마 인터페이스
+  - [x] 입력 파라미터 검증 타입
+  - [x] 도구 응답 포맷 타입
+  - [x] MCP 서버 메타데이터 타입
+- [x] 에러 응답 타입 정의
+  - [x] errorCode, errorMessage 구조
+  - [x] TTB 키 관련 에러 타입
+  - [x] API 호출 한도 초과 에러 타입
+  - [x] MCP 프로토콜 에러 타입
+  - [x] 네트워크 에러 타입
+- [x] API 관련 상수 정의 (src/constants/api.ts)
+  - [x] API 기본 URL (http://www.aladin.co.kr/ttb/api/)
+  - [x] 엔드포인트 (ItemSearch.aspx, ItemLookUp.aspx, ItemList.aspx)
+  - [x] SearchTarget 상수 (Book, Foreign, eBook, Music, DVD)
+  - [x] Sort 옵션 상수 (Accuracy, PublishTime, Title 등)
+  - [x] Cover 크기 상수 (None, Small, MidBig, Big)
+  - [x] 기본 파라미터 값 (Version: 20070901, Output: JS 등)
+  - [x] 에러 메시지 상수
+  - [x] MCP 도구 스키마 상수
+- [x] 카테고리 관련 상수/유틸리티 (src/constants/categories.ts)
+  - [x] CSV 파일 파싱 유틸리티
+  - [x] 카테고리 매핑 테이블 생성
+  - [x] 카테고리 검색/조회 유틸리티
+  - [x] 계층별 카테고리 필터링 기능
+- [x] Git 작업 완료
+  - [x] 모든 변경사항 커밋 (`feat: 타입 정의 및 상수 모듈 구현`)
+  - [x] PR 생성 (`Task 1-2: 타입 정의 및 상수 모듈 완료`) - PR #2
   - [ ] 코드 리뷰 및 main 브랜치 병합
 
 **산출물**: src/types.ts, src/constants/api.ts, src/constants/categories.ts, GitHub PR
@@ -639,7 +639,7 @@ Agent 2: Task 4-2 (에러 처리 및 로깅 강화)
 
 ## 📊 진행 상황 요약
 
-- **Phase 1**: 🔄 프로젝트 기반 구축 (2개 태스크) - Task 1-0 ✅, Task 1-1 ✅ 완료
+- **Phase 1**: ✅ 프로젝트 기반 구축 (3개 태스크) - Task 1-0 ✅, Task 1-1 ✅, Task 1-2 ✅ 완료
 - **Phase 2**: ⬜ 핵심 기능 구현 (2개 태스크)
 - **Phase 3**: ⬜ MCP 서버 구현 (2개 태스크)
 - **Phase 4**: ⬜ 품질 보증 (2개 태스크)
@@ -647,7 +647,7 @@ Agent 2: Task 4-2 (에러 처리 및 로깅 강화)
 - **Phase 6**: ⬜ 고도화 선택사항 (2개 태스크)
 
 **총 MCP 도구**: 6개 (aladin_search, aladin_book_info, aladin_bestsellers, aladin_new_books, aladin_item_list, aladin_categories)
-**전체 진행률**: 2/12 완료 (16.7%)
+**전체 진행률**: 3/13 완료 (23.1%)
 
 ---
 

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -1,0 +1,530 @@
+/**
+ * 알라딘 OpenAPI 관련 상수 정의
+ *
+ * 알라딘 API 스펙:
+ * - 기본 URL: http://www.aladin.co.kr/ttb/api/
+ * - API 버전: 20070901 (고정)
+ * - 일일 호출 한도: 5,000회
+ * - TTB 키: ttbalbert.rim1712001
+ */
+
+import type {
+  ApiVersion,
+  OutputFormat,
+  SearchTarget,
+  QueryType,
+  SortOption,
+  CoverSize,
+  OptResult,
+  ListQueryType,
+  ErrorCode,
+  McpToolDefinition
+} from '../types.js';
+
+// ===== 기본 API 설정 =====
+
+/**
+ * 알라딘 API 기본 URL
+ */
+export const ALADIN_API_BASE_URL = 'http://www.aladin.co.kr/ttb/api';
+
+/**
+ * API 엔드포인트
+ */
+export const API_ENDPOINTS = {
+  ITEM_SEARCH: 'ItemSearch.aspx',
+  ITEM_LOOKUP: 'ItemLookUp.aspx',
+  ITEM_LIST: 'ItemList.aspx'
+} as const;
+
+/**
+ * API 버전 (고정값)
+ */
+export const API_VERSION: ApiVersion = '20070901';
+
+/**
+ * 기본 출력 형식
+ */
+export const DEFAULT_OUTPUT_FORMAT: OutputFormat = 'JS';
+
+/**
+ * 일일 API 호출 제한
+ */
+export const DAILY_API_LIMIT = 5000;
+
+/**
+ * 기본 TTB 키 (환경변수에서 설정)
+ */
+export const DEFAULT_TTB_KEY = 'ttbalbert.rim1712001';
+
+// ===== 검색 관련 상수 =====
+
+/**
+ * 지원되는 검색 대상
+ */
+export const SEARCH_TARGETS: Record<SearchTarget, string> = {
+  Book: '국내도서',
+  Foreign: '외국도서',
+  eBook: '전자책',
+  Music: '음반',
+  DVD: 'DVD'
+} as const;
+
+/**
+ * 지원되는 쿼리 타입
+ */
+export const QUERY_TYPES: Record<QueryType, string> = {
+  Title: '제목',
+  Author: '저자',
+  Publisher: '출판사',
+  Keyword: '키워드'
+} as const;
+
+/**
+ * 지원되는 정렬 옵션
+ */
+export const SORT_OPTIONS: Record<SortOption, string> = {
+  Accuracy: '정확도순',
+  PublishTime: '출간일순',
+  Title: '제목순',
+  SalesPoint: '판매량순',
+  CustomerRating: '고객평점순'
+} as const;
+
+/**
+ * 지원되는 표지 이미지 크기
+ */
+export const COVER_SIZES: Record<CoverSize, string> = {
+  None: '표지없음',
+  Small: '소형',
+  MidBig: '중형',
+  Big: '대형'
+} as const;
+
+/**
+ * 지원되는 부가 정보 옵션
+ */
+export const OPT_RESULTS: Record<OptResult, string> = {
+  authors: '저자정보',
+  fulldescription: '상세설명',
+  Toc: '목차',
+  Story: '책소개',
+  categoryIdList: '카테고리정보'
+} as const;
+
+/**
+ * 지원되는 리스트 쿼리 타입
+ */
+export const LIST_QUERY_TYPES: Record<ListQueryType, string> = {
+  Bestseller: '베스트셀러',
+  NewBook: '신간도서',
+  NewSpecial: '주목할만한 신간',
+  EditorChoice: '편집자 추천',
+  ItemNewAll: '신간 전체',
+  ItemNewSpecial: '주목할만한 신간 전체'
+} as const;
+
+// ===== 기본값 설정 =====
+
+/**
+ * 검색 기본 파라미터
+ */
+export const DEFAULT_SEARCH_PARAMS = {
+  QueryType: 'Title' as QueryType,
+  SearchTarget: 'Book' as SearchTarget,
+  Sort: 'Accuracy' as SortOption,
+  Cover: 'Small' as CoverSize,
+  Start: 1,
+  MaxResults: 10,
+  Version: API_VERSION,
+  Output: DEFAULT_OUTPUT_FORMAT
+} as const;
+
+/**
+ * 상세 조회 기본 파라미터
+ */
+export const DEFAULT_LOOKUP_PARAMS = {
+  Cover: 'Small' as CoverSize,
+  Version: API_VERSION,
+  Output: DEFAULT_OUTPUT_FORMAT
+} as const;
+
+/**
+ * 리스트 조회 기본 파라미터
+ */
+export const DEFAULT_LIST_PARAMS = {
+  SearchTarget: 'Book' as SearchTarget,
+  Cover: 'Small' as CoverSize,
+  Start: 1,
+  MaxResults: 10,
+  Version: API_VERSION,
+  Output: DEFAULT_OUTPUT_FORMAT
+} as const;
+
+// ===== 검증 규칙 =====
+
+/**
+ * 파라미터 검증 규칙
+ */
+export const VALIDATION_RULES = {
+  // ISBN 검증 패턴
+  ISBN_10_PATTERN: /^\d{9}[\dX]$/,
+  ISBN_13_PATTERN: /^\d{13}$/,
+
+  // TTB 키 패턴
+  TTB_KEY_PATTERN: /^ttb[a-zA-Z0-9.]+$/,
+
+  // 페이지네이션 제한
+  MIN_START: 1,
+  MAX_START: 1000,
+  MIN_MAX_RESULTS: 1,
+  MAX_MAX_RESULTS: 50,
+
+  // 카테고리 ID 범위
+  MIN_CATEGORY_ID: 0,
+  MAX_CATEGORY_ID: 99999,
+
+  // 쿼리 길이 제한
+  MIN_QUERY_LENGTH: 1,
+  MAX_QUERY_LENGTH: 200,
+
+  // 날짜 범위 (년도)
+  MIN_YEAR: 1900,
+  MAX_YEAR: new Date().getFullYear() + 1,
+
+  // 월 범위
+  MIN_MONTH: 1,
+  MAX_MONTH: 12,
+
+  // 주 범위
+  MIN_WEEK: 1,
+  MAX_WEEK: 5
+} as const;
+
+// ===== 에러 메시지 =====
+
+/**
+ * 에러 코드별 메시지
+ */
+export const ERROR_MESSAGES: Record<ErrorCode, string> = {
+  [100]: '잘못된 TTB 키입니다. API 키를 확인해 주세요.',
+  [200]: '필수 파라미터가 누락되었습니다.',
+  [300]: '잘못된 파라미터 값입니다.',
+  [900]: '시스템 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.',
+  [901]: '일일 호출 한도(5,000회)를 초과했습니다. 내일 다시 시도해 주세요.'
+} as const;
+
+/**
+ * 클라이언트 에러 메시지
+ */
+export const CLIENT_ERROR_MESSAGES = {
+  NETWORK_ERROR: '네트워크 연결에 실패했습니다.',
+  TIMEOUT_ERROR: '요청 시간이 초과되었습니다.',
+  INVALID_RESPONSE: '유효하지 않은 응답 형식입니다.',
+  RATE_LIMIT_EXCEEDED: 'API 호출 빈도 제한을 초과했습니다.',
+  INVALID_PARAMETER: '유효하지 않은 파라미터입니다.',
+  MISSING_PARAMETER: '필수 파라미터가 누락되었습니다.',
+  INVALID_ISBN: '유효하지 않은 ISBN 형식입니다.',
+  INVALID_CATEGORY: '유효하지 않은 카테고리 ID입니다.',
+  INVALID_DATE: '유효하지 않은 날짜 형식입니다.'
+} as const;
+
+// ===== HTTP 설정 =====
+
+/**
+ * HTTP 요청 설정
+ */
+export const HTTP_CONFIG = {
+  TIMEOUT: 10000, // 10초
+  MAX_RETRIES: 3,
+  RETRY_DELAY: 1000, // 1초
+  MAX_RETRY_DELAY: 8000, // 8초
+  RETRY_MULTIPLIER: 2,
+
+  // 헤더 설정
+  HEADERS: {
+    'User-Agent': 'Aladin-MCP-Server/1.0.0',
+    'Accept': 'application/json, text/plain, */*',
+    'Accept-Encoding': 'gzip, deflate',
+    'Connection': 'keep-alive'
+  }
+} as const;
+
+// ===== 캐시 설정 =====
+
+/**
+ * 캐시 설정
+ */
+export const CACHE_CONFIG = {
+  // TTL (Time To Live) 설정 (밀리초)
+  SEARCH_TTL: 5 * 60 * 1000, // 5분
+  LOOKUP_TTL: 30 * 60 * 1000, // 30분
+  LIST_TTL: 10 * 60 * 1000, // 10분
+  CATEGORY_TTL: 24 * 60 * 60 * 1000, // 24시간
+
+  // 캐시 크기 제한
+  MAX_CACHE_SIZE: 1000,
+
+  // 캐시 키 접두사
+  KEY_PREFIX: 'aladin_mcp'
+} as const;
+
+// ===== MCP 도구 스키마 =====
+
+/**
+ * aladin_search 도구 스키마
+ */
+export const ALADIN_SEARCH_SCHEMA: McpToolDefinition = {
+  name: 'aladin_search',
+  description: '알라딘에서 도서를 검색합니다. 키워드, 제목, 저자, 출판사로 검색할 수 있습니다.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      query: {
+        type: 'string',
+        description: '검색할 키워드 (필수)',
+        minLength: VALIDATION_RULES.MIN_QUERY_LENGTH,
+        maxLength: VALIDATION_RULES.MAX_QUERY_LENGTH
+      },
+      queryType: {
+        type: 'string',
+        enum: Object.keys(QUERY_TYPES),
+        description: '검색 타입 (Title: 제목, Author: 저자, Publisher: 출판사, Keyword: 키워드)',
+        default: 'Title'
+      },
+      searchTarget: {
+        type: 'string',
+        enum: Object.keys(SEARCH_TARGETS),
+        description: '검색 대상 (Book: 국내도서, Foreign: 외국도서, eBook: 전자책)',
+        default: 'Book'
+      },
+      sort: {
+        type: 'string',
+        enum: Object.keys(SORT_OPTIONS),
+        description: '정렬 순서',
+        default: 'Accuracy'
+      },
+      categoryId: {
+        type: 'number',
+        description: '카테고리 ID (선택사항)',
+        minimum: VALIDATION_RULES.MIN_CATEGORY_ID,
+        maximum: VALIDATION_RULES.MAX_CATEGORY_ID
+      },
+      start: {
+        type: 'number',
+        description: '검색 시작 위치',
+        minimum: VALIDATION_RULES.MIN_START,
+        maximum: VALIDATION_RULES.MAX_START,
+        default: 1
+      },
+      maxResults: {
+        type: 'number',
+        description: '검색 결과 개수',
+        minimum: VALIDATION_RULES.MIN_MAX_RESULTS,
+        maximum: VALIDATION_RULES.MAX_MAX_RESULTS,
+        default: 10
+      }
+    },
+    required: ['query']
+  }
+};
+
+/**
+ * aladin_book_info 도구 스키마
+ */
+export const ALADIN_BOOK_INFO_SCHEMA: McpToolDefinition = {
+  name: 'aladin_book_info',
+  description: 'ISBN 또는 상품 ID로 도서의 상세 정보를 조회합니다.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      itemId: {
+        type: 'string',
+        description: '알라딘 상품 ID'
+      },
+      isbn: {
+        type: 'string',
+        description: 'ISBN-10 또는 ISBN-13',
+        pattern: '^(\\d{10}|\\d{13})$'
+      },
+      isbn13: {
+        type: 'string',
+        description: 'ISBN-13',
+        pattern: '^\\d{13}$'
+      },
+      cover: {
+        type: 'string',
+        enum: Object.keys(COVER_SIZES),
+        description: '표지 이미지 크기',
+        default: 'Small'
+      },
+      optResult: {
+        type: 'array',
+        items: {
+          type: 'string',
+          enum: Object.keys(OPT_RESULTS)
+        },
+        description: '부가 정보 옵션'
+      }
+    }
+  }
+};
+
+/**
+ * aladin_bestsellers 도구 스키마
+ */
+export const ALADIN_BESTSELLERS_SCHEMA: McpToolDefinition = {
+  name: 'aladin_bestsellers',
+  description: '분야별 베스트셀러 목록을 조회합니다.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      categoryId: {
+        type: 'number',
+        description: '카테고리 ID (0: 전체)',
+        minimum: VALIDATION_RULES.MIN_CATEGORY_ID,
+        maximum: VALIDATION_RULES.MAX_CATEGORY_ID,
+        default: 0
+      },
+      searchTarget: {
+        type: 'string',
+        enum: Object.keys(SEARCH_TARGETS),
+        description: '검색 대상',
+        default: 'Book'
+      },
+      year: {
+        type: 'number',
+        description: '년도',
+        minimum: VALIDATION_RULES.MIN_YEAR,
+        maximum: VALIDATION_RULES.MAX_YEAR
+      },
+      month: {
+        type: 'number',
+        description: '월',
+        minimum: VALIDATION_RULES.MIN_MONTH,
+        maximum: VALIDATION_RULES.MAX_MONTH
+      },
+      week: {
+        type: 'number',
+        description: '주',
+        minimum: VALIDATION_RULES.MIN_WEEK,
+        maximum: VALIDATION_RULES.MAX_WEEK
+      },
+      start: {
+        type: 'number',
+        description: '시작 위치',
+        minimum: VALIDATION_RULES.MIN_START,
+        default: 1
+      },
+      maxResults: {
+        type: 'number',
+        description: '결과 개수',
+        minimum: VALIDATION_RULES.MIN_MAX_RESULTS,
+        maximum: VALIDATION_RULES.MAX_MAX_RESULTS,
+        default: 10
+      }
+    }
+  }
+};
+
+/**
+ * aladin_new_books 도구 스키마
+ */
+export const ALADIN_NEW_BOOKS_SCHEMA: McpToolDefinition = {
+  name: 'aladin_new_books',
+  description: '신간 도서 목록을 조회합니다.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      queryType: {
+        type: 'string',
+        enum: ['NewBook', 'NewSpecial'],
+        description: '신간 타입 (NewBook: 신간, NewSpecial: 주목할만한 신간)',
+        default: 'NewBook'
+      },
+      categoryId: {
+        type: 'number',
+        description: '카테고리 ID',
+        minimum: VALIDATION_RULES.MIN_CATEGORY_ID,
+        maximum: VALIDATION_RULES.MAX_CATEGORY_ID
+      },
+      searchTarget: {
+        type: 'string',
+        enum: Object.keys(SEARCH_TARGETS),
+        description: '검색 대상',
+        default: 'Book'
+      },
+      start: {
+        type: 'number',
+        description: '시작 위치',
+        minimum: VALIDATION_RULES.MIN_START,
+        default: 1
+      },
+      maxResults: {
+        type: 'number',
+        description: '결과 개수',
+        minimum: VALIDATION_RULES.MIN_MAX_RESULTS,
+        maximum: VALIDATION_RULES.MAX_MAX_RESULTS,
+        default: 10
+      }
+    }
+  }
+};
+
+/**
+ * aladin_categories 도구 스키마
+ */
+export const ALADIN_CATEGORIES_SCHEMA: McpToolDefinition = {
+  name: 'aladin_categories',
+  description: '카테고리 정보를 조회하거나 검색합니다.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      categoryName: {
+        type: 'string',
+        description: '카테고리명으로 검색'
+      },
+      categoryId: {
+        type: 'number',
+        description: '카테고리 ID로 조회',
+        minimum: VALIDATION_RULES.MIN_CATEGORY_ID,
+        maximum: VALIDATION_RULES.MAX_CATEGORY_ID
+      },
+      depth: {
+        type: 'number',
+        description: '카테고리 깊이 (1-5)',
+        minimum: 1,
+        maximum: 5
+      }
+    }
+  }
+};
+
+/**
+ * 모든 MCP 도구 스키마
+ */
+export const MCP_TOOL_SCHEMAS = {
+  aladin_search: ALADIN_SEARCH_SCHEMA,
+  aladin_book_info: ALADIN_BOOK_INFO_SCHEMA,
+  aladin_bestsellers: ALADIN_BESTSELLERS_SCHEMA,
+  aladin_new_books: ALADIN_NEW_BOOKS_SCHEMA,
+  aladin_categories: ALADIN_CATEGORIES_SCHEMA
+} as const;
+
+// ===== 도구 목록 =====
+
+/**
+ * 지원되는 MCP 도구 목록
+ */
+export const SUPPORTED_TOOLS = Object.keys(MCP_TOOL_SCHEMAS);
+
+/**
+ * 도구별 설명
+ */
+export const TOOL_DESCRIPTIONS = {
+  aladin_search: '키워드로 도서 검색',
+  aladin_book_info: 'ISBN으로 도서 상세 정보 조회',
+  aladin_bestsellers: '분야별 베스트셀러 목록 조회',
+  aladin_new_books: '신간 도서 목록 조회',
+  aladin_categories: '카테고리 정보 조회'
+} as const;

--- a/src/constants/categories.ts
+++ b/src/constants/categories.ts
@@ -1,0 +1,445 @@
+/**
+ * 알라딘 카테고리 관련 상수 및 유틸리티
+ *
+ * CSV 파일: aladin_Category_CID_20210927.csv
+ * 구조: CID, 카테고리명, 몰, 1Depth, 2Depth, 3Depth, 4Depth, 5Depth
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import csvParser from 'csv-parser';
+import type {
+  CategoryCsvRow,
+  ParsedCategory,
+  CategorySearchResult,
+  ValidationResult
+} from '../types.js';
+
+// ===== 카테고리 파일 설정 =====
+
+/**
+ * 카테고리 CSV 파일 경로
+ */
+export const CATEGORY_CSV_PATH = path.join(process.cwd(), 'aladin_Category_CID_20210927.csv');
+
+/**
+ * 카테고리 데이터 캐시
+ */
+let categoryCache: ParsedCategory[] | null = null;
+let categoryMap: Map<number, ParsedCategory> | null = null;
+let categoryNameMap: Map<string, ParsedCategory[]> | null = null;
+
+// ===== 카테고리 상수 =====
+
+/**
+ * 지원되는 몰 구분
+ */
+export const MALL_TYPES = {
+  DOMESTIC: '국내도서',
+  FOREIGN: '외국도서',
+  EBOOK: '전자책',
+  MUSIC: '음반',
+  DVD: 'DVD'
+} as const;
+
+/**
+ * 카테고리 깊이 제한
+ */
+export const CATEGORY_DEPTHS = {
+  MIN_DEPTH: 1,
+  MAX_DEPTH: 5
+} as const;
+
+/**
+ * 특별 카테고리 ID
+ */
+export const SPECIAL_CATEGORIES = {
+  ALL: 0, // 전체 카테고리
+  BOOK: 1, // 도서 (일반적인 기본 카테고리)
+  BESTSELLER: 1230 // 베스트셀러에서 자주 사용되는 카테고리
+} as const;
+
+// ===== CSV 파싱 유틸리티 =====
+
+/**
+ * CSV 파일을 파싱하여 카테고리 데이터를 로드합니다.
+ */
+export async function loadCategoryData(): Promise<ParsedCategory[]> {
+  if (categoryCache) {
+    return categoryCache;
+  }
+
+  return new Promise((resolve, reject) => {
+    const categories: ParsedCategory[] = [];
+
+    // CSV 파일 존재 여부 확인
+    if (!fs.existsSync(CATEGORY_CSV_PATH)) {
+      reject(new Error(`카테고리 CSV 파일을 찾을 수 없습니다: ${CATEGORY_CSV_PATH}`));
+      return;
+    }
+
+    fs.createReadStream(CATEGORY_CSV_PATH)
+      .pipe(csvParser())
+      .on('data', (row: any) => {
+        try {
+          const parsedCategory = parseCategory(row);
+          if (parsedCategory) {
+            categories.push(parsedCategory);
+          }
+        } catch (error: any) {
+          console.warn('카테고리 파싱 중 오류:', error, row);
+        }
+      })
+      .on('end', () => {
+        categoryCache = categories;
+        buildCategoryMaps(categories);
+        resolve(categories);
+      })
+      .on('error', (error: any) => {
+        reject(new Error(`CSV 파일 읽기 실패: ${error.message}`));
+      });
+  });
+}
+
+/**
+ * CSV 행을 ParsedCategory 객체로 변환합니다.
+ */
+function parseCategory(row: any): ParsedCategory | null {
+  try {
+    const cid = parseInt(row.CID?.toString() || '0', 10);
+    if (isNaN(cid) || cid <= 0) {
+      return null;
+    }
+
+    const categoryName = row['카테고리명']?.toString()?.trim();
+    const mallType = row['몰']?.toString()?.trim();
+
+    if (!categoryName || !mallType) {
+      return null;
+    }
+
+    // Depth별 카테고리명 추출
+    const depths = [
+      row['1Depth']?.toString()?.trim(),
+      row['2Depth']?.toString()?.trim(),
+      row['3Depth']?.toString()?.trim(),
+      row['4Depth']?.toString()?.trim(),
+      row['5Depth']?.toString()?.trim()
+    ].filter(Boolean);
+
+    // 실제 depth 계산 (비어있지 않은 depth의 개수)
+    const actualDepth = depths.length;
+
+    // 부모 카테고리 정보 계산
+    const parentName = actualDepth > 1 ? depths[actualDepth - 2] : undefined;
+
+    return {
+      id: cid,
+      name: categoryName,
+      depth: actualDepth,
+      parentName,
+      fullPath: depths,
+      mallType
+    };
+  } catch (error) {
+    console.warn('카테고리 행 파싱 실패:', error, row);
+    return null;
+  }
+}
+
+/**
+ * 카테고리 맵을 구축합니다.
+ */
+function buildCategoryMaps(categories: ParsedCategory[]): void {
+  // ID 기반 맵
+  categoryMap = new Map();
+  categories.forEach(category => {
+    categoryMap!.set(category.id, category);
+  });
+
+  // 이름 기반 맵 (중복 가능하므로 배열)
+  categoryNameMap = new Map();
+  categories.forEach(category => {
+    const existing = categoryNameMap!.get(category.name) || [];
+    existing.push(category);
+    categoryNameMap!.set(category.name, existing);
+  });
+}
+
+// ===== 카테고리 조회 함수 =====
+
+/**
+ * 카테고리 ID로 카테고리 정보를 조회합니다.
+ */
+export async function getCategoryById(categoryId: number): Promise<ParsedCategory | null> {
+  if (!categoryMap) {
+    await loadCategoryData();
+  }
+
+  return categoryMap!.get(categoryId) || null;
+}
+
+/**
+ * 카테고리명으로 카테고리 정보를 검색합니다.
+ */
+export async function getCategoriesByName(categoryName: string): Promise<ParsedCategory[]> {
+  if (!categoryNameMap) {
+    await loadCategoryData();
+  }
+
+  return categoryNameMap!.get(categoryName) || [];
+}
+
+/**
+ * 부분 카테고리명으로 카테고리를 검색합니다.
+ */
+export async function searchCategories(
+  query: string,
+  options: {
+    mallType?: string;
+    depth?: number;
+    limit?: number;
+  } = {}
+): Promise<CategorySearchResult> {
+  if (!categoryCache) {
+    await loadCategoryData();
+  }
+
+  const { mallType, depth, limit = 50 } = options;
+  const queryLower = query.toLowerCase();
+
+  let filteredCategories = categoryCache!.filter(category => {
+    // 이름 매칭
+    const nameMatch = category.name.toLowerCase().includes(queryLower) ||
+                     category.fullPath.some(pathItem =>
+                       pathItem.toLowerCase().includes(queryLower)
+                     );
+
+    if (!nameMatch) return false;
+
+    // 몰 타입 필터
+    if (mallType && category.mallType !== mallType) return false;
+
+    // 깊이 필터
+    if (depth && category.depth !== depth) return false;
+
+    return true;
+  });
+
+  // 관련성 점수로 정렬 (정확한 매치를 우선순위로)
+  filteredCategories.sort((a, b) => {
+    const aExactMatch = a.name.toLowerCase() === queryLower;
+    const bExactMatch = b.name.toLowerCase() === queryLower;
+
+    if (aExactMatch && !bExactMatch) return -1;
+    if (!aExactMatch && bExactMatch) return 1;
+
+    // 이름 길이순 (짧은 것이 더 관련성 높음)
+    return a.name.length - b.name.length;
+  });
+
+  // 제한 적용
+  if (limit > 0) {
+    filteredCategories = filteredCategories.slice(0, limit);
+  }
+
+  return {
+    categories: filteredCategories,
+    totalCount: filteredCategories.length
+  };
+}
+
+/**
+ * 특정 깊이의 모든 카테고리를 조회합니다.
+ */
+export async function getCategoriesByDepth(depth: number): Promise<ParsedCategory[]> {
+  if (!categoryCache) {
+    await loadCategoryData();
+  }
+
+  if (depth < CATEGORY_DEPTHS.MIN_DEPTH || depth > CATEGORY_DEPTHS.MAX_DEPTH) {
+    throw new Error(`유효하지 않은 깊이입니다. ${CATEGORY_DEPTHS.MIN_DEPTH}-${CATEGORY_DEPTHS.MAX_DEPTH} 사이의 값이어야 합니다.`);
+  }
+
+  return categoryCache!.filter(category => category.depth === depth);
+}
+
+/**
+ * 몰 타입별 카테고리를 조회합니다.
+ */
+export async function getCategoriesByMallType(mallType: string): Promise<ParsedCategory[]> {
+  if (!categoryCache) {
+    await loadCategoryData();
+  }
+
+  return categoryCache!.filter(category => category.mallType === mallType);
+}
+
+/**
+ * 부모 카테고리의 하위 카테고리들을 조회합니다.
+ */
+export async function getSubCategories(parentCategoryName: string): Promise<ParsedCategory[]> {
+  if (!categoryCache) {
+    await loadCategoryData();
+  }
+
+  return categoryCache!.filter(category =>
+    category.parentName === parentCategoryName
+  );
+}
+
+// ===== 카테고리 검증 함수 =====
+
+/**
+ * 카테고리 ID의 유효성을 검증합니다.
+ */
+export async function validateCategoryId(categoryId: number): Promise<ValidationResult> {
+  const errors: string[] = [];
+
+  // 기본 범위 검사
+  if (categoryId < 0 || categoryId > 99999) {
+    errors.push('카테고리 ID는 0-99999 범위여야 합니다.');
+  }
+
+  // 특별 카테고리 검사
+  if (categoryId === SPECIAL_CATEGORIES.ALL) {
+    return { isValid: true, errors: [] };
+  }
+
+  // 실제 카테고리 존재 여부 확인
+  try {
+    const category = await getCategoryById(categoryId);
+    if (!category) {
+      errors.push(`존재하지 않는 카테고리 ID입니다: ${categoryId}`);
+    }
+  } catch (error) {
+    errors.push(`카테고리 검증 중 오류가 발생했습니다: ${error}`);
+  }
+
+  return {
+    isValid: errors.length === 0,
+    errors
+  };
+}
+
+/**
+ * 카테고리명의 유효성을 검증합니다.
+ */
+export async function validateCategoryName(categoryName: string): Promise<ValidationResult> {
+  const errors: string[] = [];
+
+  if (!categoryName || categoryName.trim().length === 0) {
+    errors.push('카테고리명은 비어있을 수 없습니다.');
+    return { isValid: false, errors };
+  }
+
+  const trimmedName = categoryName.trim();
+
+  if (trimmedName.length > 100) {
+    errors.push('카테고리명은 100자를 초과할 수 없습니다.');
+  }
+
+  // 실제 카테고리 존재 여부 확인
+  try {
+    const categories = await getCategoriesByName(trimmedName);
+    if (categories.length === 0) {
+      // 부분 검색으로도 확인
+      const searchResult = await searchCategories(trimmedName, { limit: 1 });
+      if (searchResult.totalCount === 0) {
+        errors.push(`존재하지 않는 카테고리명입니다: ${trimmedName}`);
+      }
+    }
+  } catch (error) {
+    errors.push(`카테고리 검증 중 오류가 발생했습니다: ${error}`);
+  }
+
+  return {
+    isValid: errors.length === 0,
+    errors
+  };
+}
+
+// ===== 카테고리 유틸리티 함수 =====
+
+/**
+ * 카테고리의 전체 경로를 문자열로 반환합니다.
+ */
+export function getCategoryPath(category: ParsedCategory): string {
+  return category.fullPath.join(' > ');
+}
+
+/**
+ * 카테고리를 표시용 문자열로 포맷합니다.
+ */
+export function formatCategoryForDisplay(category: ParsedCategory): string {
+  const path = getCategoryPath(category);
+  return `[${category.id}] ${path} (${category.mallType})`;
+}
+
+/**
+ * 카테고리 데이터를 JSON 형태로 내보냅니다.
+ */
+export async function exportCategoriesAsJson(): Promise<string> {
+  if (!categoryCache) {
+    await loadCategoryData();
+  }
+
+  return JSON.stringify(categoryCache, null, 2);
+}
+
+/**
+ * 카테고리 통계 정보를 반환합니다.
+ */
+export async function getCategoryStats(): Promise<{
+  totalCount: number;
+  byMallType: Record<string, number>;
+  byDepth: Record<number, number>;
+}> {
+  if (!categoryCache) {
+    await loadCategoryData();
+  }
+
+  const byMallType: Record<string, number> = {};
+  const byDepth: Record<number, number> = {};
+
+  categoryCache!.forEach(category => {
+    // 몰 타입별 통계
+    byMallType[category.mallType] = (byMallType[category.mallType] || 0) + 1;
+
+    // 깊이별 통계
+    byDepth[category.depth] = (byDepth[category.depth] || 0) + 1;
+  });
+
+  return {
+    totalCount: categoryCache!.length,
+    byMallType,
+    byDepth
+  };
+}
+
+/**
+ * 캐시를 초기화합니다.
+ */
+export function clearCategoryCache(): void {
+  categoryCache = null;
+  categoryMap = null;
+  categoryNameMap = null;
+}
+
+/**
+ * 카테고리 데이터가 로드되었는지 확인합니다.
+ */
+export function isCategoryDataLoaded(): boolean {
+  return categoryCache !== null;
+}
+
+// ===== 자동 초기화 =====
+
+/**
+ * 모듈 로드 시 카테고리 데이터를 자동으로 로드합니다.
+ * 실패 시 경고만 출력하고 계속 진행합니다.
+ */
+loadCategoryData().catch(error => {
+  console.warn('카테고리 데이터 자동 로드 실패:', error.message);
+  console.warn('카테고리 관련 기능이 제한될 수 있습니다.');
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,504 @@
+/**
+ * 알라딘 OpenAPI MCP 서버용 타입 정의
+ *
+ * 알라딘 API 스펙:
+ * - Version: 20070901
+ * - 응답 형식: XML, JSON
+ * - 일일 호출 한도: 5,000회
+ */
+
+// ===== 기본 타입 정의 =====
+
+/**
+ * API 버전 타입
+ */
+export type ApiVersion = '20070901';
+
+/**
+ * 출력 형식 타입
+ */
+export type OutputFormat = 'XML' | 'JS';
+
+/**
+ * 검색 대상 타입
+ */
+export type SearchTarget = 'Book' | 'Foreign' | 'eBook' | 'Music' | 'DVD';
+
+/**
+ * 검색 쿼리 타입
+ */
+export type QueryType = 'Title' | 'Author' | 'Publisher' | 'Keyword';
+
+/**
+ * 정렬 옵션 타입
+ */
+export type SortOption = 'Accuracy' | 'PublishTime' | 'Title' | 'SalesPoint' | 'CustomerRating';
+
+/**
+ * 표지 이미지 크기 타입
+ */
+export type CoverSize = 'None' | 'Small' | 'MidBig' | 'Big';
+
+/**
+ * 부가 정보 옵션 타입
+ */
+export type OptResult = 'authors' | 'fulldescription' | 'Toc' | 'Story' | 'categoryIdList';
+
+/**
+ * 리스트 쿼리 타입 (베스트셀러/신간 등)
+ */
+export type ListQueryType =
+  | 'Bestseller'
+  | 'NewBook'
+  | 'NewSpecial'
+  | 'EditorChoice'
+  | 'ItemNewAll'
+  | 'ItemNewSpecial';
+
+/**
+ * 기간 타입 (베스트셀러 등에서 사용)
+ */
+export type PeriodType = 'Daily' | 'Weekly' | 'Monthly';
+
+// ===== 검색 파라미터 타입 =====
+
+/**
+ * 공통 API 파라미터
+ */
+export interface BaseApiParams {
+  TTBKey: string;
+  Version: ApiVersion;
+  Output?: OutputFormat;
+}
+
+/**
+ * 페이지네이션 파라미터
+ */
+export interface PaginationParams {
+  Start?: number;
+  MaxResults?: number;
+}
+
+/**
+ * 도서 검색 파라미터 (ItemSearch.aspx)
+ */
+export interface SearchBooksParams extends BaseApiParams, PaginationParams {
+  Query: string;
+  QueryType?: QueryType;
+  SearchTarget?: SearchTarget;
+  Sort?: SortOption;
+  Cover?: CoverSize;
+  CategoryId?: number;
+  OptResult?: OptResult[];
+}
+
+/**
+ * 도서 상세 조회 파라미터 (ItemLookUp.aspx)
+ */
+export interface BookDetailsParams extends BaseApiParams {
+  ItemId?: string;
+  ISBN?: string;
+  ISBN13?: string;
+  Cover?: CoverSize;
+  OptResult?: OptResult[];
+}
+
+/**
+ * 리스트 조회 파라미터 (ItemList.aspx)
+ */
+export interface ItemListParams extends BaseApiParams, PaginationParams {
+  QueryType: ListQueryType;
+  SearchTarget?: SearchTarget;
+  CategoryId?: number;
+  Cover?: CoverSize;
+  Year?: number;
+  Month?: number;
+  Week?: number;
+}
+
+// ===== 알라딘 API 응답 타입 =====
+
+/**
+ * 기본 도서 정보
+ */
+export interface BookItem {
+  itemId: number;
+  title: string;
+  link: string;
+  author: string;
+  pubDate: string;
+  description: string;
+  isbn: string;
+  isbn13: string;
+  priceSales: number;
+  priceStandard: number;
+  mallType: string;
+  stockStatus: string;
+  mileage: number;
+  cover: string;
+  categoryId: number;
+  categoryName: string;
+  publisher: string;
+  salesPoint: number;
+  adult: boolean;
+  fixedPrice: boolean;
+  customerReviewRank: number;
+  bestDuration?: string;
+  bestRank?: number;
+}
+
+/**
+ * 서브 정보 (부가 정보)
+ */
+export interface SubInfo {
+  authors?: Author[];
+  fulldescription?: string;
+  toc?: string;
+  story?: string;
+  categoryIdList?: CategoryInfo[];
+  ratingInfo?: RatingInfo;
+  bestSellerRank?: BestSellerRank[];
+  cardPromotionList?: CardPromotion[];
+  packList?: PackItem[];
+}
+
+/**
+ * 저자 정보
+ */
+export interface Author {
+  authorId: number;
+  authorName: string;
+  authorType: string;
+  authorInfo: string;
+}
+
+/**
+ * 카테고리 정보
+ */
+export interface CategoryInfo {
+  categoryId: number;
+  categoryName: string;
+  categoryDepth: number;
+}
+
+/**
+ * 평점 정보
+ */
+export interface RatingInfo {
+  ratingScore: number;
+  ratingCount: number;
+  commentReviewCount: number;
+  myReviewCount: number;
+}
+
+/**
+ * 베스트셀러 순위 정보
+ */
+export interface BestSellerRank {
+  categoryId: number;
+  categoryName: string;
+  bestRank: number;
+  period: string;
+}
+
+/**
+ * 카드 프로모션 정보
+ */
+export interface CardPromotion {
+  cardCompany: string;
+  cardType: string;
+  discountAmount: number;
+  discountRate: number;
+}
+
+/**
+ * 패키지 아이템
+ */
+export interface PackItem {
+  itemId: number;
+  title: string;
+  author: string;
+  cover: string;
+}
+
+/**
+ * 완전한 도서 정보 (SubInfo 포함)
+ */
+export interface CompleteBookItem extends BookItem {
+  subInfo?: SubInfo;
+}
+
+/**
+ * 검색 응답 (ItemSearch)
+ */
+export interface SearchResponse {
+  version: string;
+  title: string;
+  link: string;
+  pubDate: string;
+  totalResults: number;
+  startIndex: number;
+  itemsPerPage: number;
+  query: string;
+  item: CompleteBookItem[];
+}
+
+/**
+ * 상세 조회 응답 (ItemLookUp)
+ */
+export interface LookupResponse {
+  version: string;
+  title: string;
+  link: string;
+  pubDate: string;
+  item: CompleteBookItem[];
+}
+
+/**
+ * 리스트 조회 응답 (ItemList)
+ */
+export interface ListResponse {
+  version: string;
+  title: string;
+  link: string;
+  pubDate: string;
+  item: CompleteBookItem[];
+}
+
+// ===== 에러 응답 타입 =====
+
+/**
+ * 알라딘 API 에러 응답
+ */
+export interface AladinApiError {
+  errorCode: number;
+  errorMessage: string;
+}
+
+/**
+ * 에러 코드 열거형
+ */
+export enum ErrorCode {
+  INVALID_TTB_KEY = 100,
+  MISSING_REQUIRED_PARAM = 200,
+  INVALID_PARAM_VALUE = 300,
+  SYSTEM_ERROR = 900,
+  DAILY_LIMIT_EXCEEDED = 901
+}
+
+/**
+ * 표준화된 에러 응답
+ */
+export interface StandardError {
+  code: ErrorCode;
+  message: string;
+  originalError?: AladinApiError;
+  timestamp: string;
+}
+
+// ===== MCP 도구 관련 타입 =====
+
+/**
+ * MCP 도구 입력 스키마
+ */
+export interface McpToolSchema {
+  type: 'object';
+  properties: Record<string, any>;
+  required?: string[];
+}
+
+/**
+ * MCP 도구 정의
+ */
+export interface McpToolDefinition {
+  name: string;
+  description: string;
+  inputSchema: McpToolSchema;
+}
+
+/**
+ * aladin_search 도구 입력
+ */
+export interface AladinSearchInput {
+  query: string;
+  queryType?: QueryType;
+  searchTarget?: SearchTarget;
+  sort?: SortOption;
+  cover?: CoverSize;
+  categoryId?: number;
+  start?: number;
+  maxResults?: number;
+  optResult?: OptResult[];
+}
+
+/**
+ * aladin_book_info 도구 입력
+ */
+export interface AladinBookInfoInput {
+  itemId?: string;
+  isbn?: string;
+  isbn13?: string;
+  cover?: CoverSize;
+  optResult?: OptResult[];
+}
+
+/**
+ * aladin_bestsellers 도구 입력
+ */
+export interface AladinBestsellersInput {
+  categoryId?: number;
+  searchTarget?: SearchTarget;
+  year?: number;
+  month?: number;
+  week?: number;
+  start?: number;
+  maxResults?: number;
+  cover?: CoverSize;
+}
+
+/**
+ * aladin_new_books 도구 입력
+ */
+export interface AladinNewBooksInput {
+  queryType?: 'NewBook' | 'NewSpecial';
+  categoryId?: number;
+  searchTarget?: SearchTarget;
+  start?: number;
+  maxResults?: number;
+  cover?: CoverSize;
+}
+
+/**
+ * aladin_item_list 도구 입력
+ */
+export interface AladinItemListInput {
+  queryType: ListQueryType;
+  categoryId?: number;
+  searchTarget?: SearchTarget;
+  start?: number;
+  maxResults?: number;
+  cover?: CoverSize;
+}
+
+/**
+ * aladin_categories 도구 입력
+ */
+export interface AladinCategoriesInput {
+  categoryName?: string;
+  categoryId?: number;
+  depth?: number;
+}
+
+/**
+ * MCP 도구 응답 표준 포맷
+ */
+export interface McpToolResponse<T = any> {
+  success: boolean;
+  data?: T;
+  error?: StandardError;
+  metadata?: {
+    totalResults?: number;
+    startIndex?: number;
+    itemsPerPage?: number;
+    query?: string;
+    timestamp: string;
+  };
+}
+
+// ===== 카테고리 관련 타입 =====
+
+/**
+ * 카테고리 CSV 데이터 구조
+ */
+export interface CategoryCsvRow {
+  CID: number;
+  '1Depth': string;
+  '2Depth': string;
+  '3Depth': string;
+  '4Depth': string;
+  '5Depth': string;
+  '몰구분': string;
+}
+
+/**
+ * 파싱된 카테고리 정보
+ */
+export interface ParsedCategory {
+  id: number;
+  name: string;
+  depth: number;
+  parentId?: number;
+  parentName?: string;
+  fullPath: string[];
+  mallType: string;
+}
+
+/**
+ * 카테고리 검색 결과
+ */
+export interface CategorySearchResult {
+  categories: ParsedCategory[];
+  totalCount: number;
+}
+
+// ===== 서버 설정 및 상태 타입 =====
+
+/**
+ * 서버 메타데이터
+ */
+export interface ServerMetadata {
+  name: string;
+  version: string;
+  description: string;
+  apiVersion: ApiVersion;
+  supportedTools: string[];
+}
+
+/**
+ * API 사용량 추적
+ */
+export interface ApiUsageStats {
+  dailyCount: number;
+  dailyLimit: number;
+  lastReset: Date;
+  lastCall: Date;
+}
+
+/**
+ * 서버 상태
+ */
+export interface ServerStatus {
+  isHealthy: boolean;
+  uptime: number;
+  apiUsage: ApiUsageStats;
+  lastError?: StandardError;
+}
+
+// ===== 유틸리티 타입 =====
+
+/**
+ * 부분 업데이트용 타입
+ */
+export type PartialBy<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
+
+/**
+ * 필수 필드만 포함하는 타입
+ */
+export type RequiredOnly<T, K extends keyof T> = Pick<T, K> & Partial<Omit<T, K>>;
+
+/**
+ * 검증 결과 타입
+ */
+export interface ValidationResult {
+  isValid: boolean;
+  errors: string[];
+}
+
+/**
+ * 캐시 엔트리 타입
+ */
+export interface CacheEntry<T> {
+  data: T;
+  timestamp: number;
+  ttl: number;
+}


### PR DESCRIPTION
## Task 완료 내용
- [x] 알라딘 API 응답 인터페이스 정의 (src/types.ts)
- [x] 검색 파라미터 타입 정의
- [x] 도서 정보 타입 정의
- [x] 베스트셀러/신간 리스트 타입 정의
- [x] MCP 도구별 입력/출력 타입 정의
- [x] 에러 응답 타입 정의
- [x] API 관련 상수 정의 (src/constants/api.ts)
- [x] 카테고리 관련 상수/유틸리티 (src/constants/categories.ts)
- [x] 타입 검사 통과 (TypeScript)

## 변경 사항
### src/types.ts
- 알라딘 API 응답 타입 (ItemSearch, ItemLookUp, ItemList)
- 검색 파라미터 및 리스트 파라미터 타입
- 도서 정보 및 서브 정보 인터페이스
- MCP 도구 입력/출력 타입
- 에러 응답 및 서버 상태 타입
- 카테고리 CSV 데이터 구조 및 파싱 타입
- 유틸리티 타입 (ValidationResult, CacheEntry 등)

### src/constants/api.ts
- 알라딘 API 기본 설정 (URL, 엔드포인트, 버전)
- 검색 관련 상수 (SearchTarget, QueryType, SortOption 등)
- 파라미터 검증 규칙 및 제한값
- 에러 메시지 상수 (에러코드별, 클라이언트 에러)
- HTTP 요청 설정 (타임아웃, 재시도, 헤더)
- 캐시 설정 (TTL, 크기 제한, 키 접두사)
- MCP 도구 스키마 정의 (5개 도구별 JSON Schema)

### src/constants/categories.ts
- CSV 파일 파싱 및 카테고리 데이터 로드
- 카테고리 검색, 조회, 검증 함수
- 카테고리 맵 구축 및 캐시 관리
- 깊이별, 몰타입별 카테고리 조회
- 카테고리 통계 및 포맷팅 유틸리티
- 자동 초기화 및 에러 처리

## 기술적 세부사항
- 총 400여 줄의 포괄적인 타입 정의
- 알라딘 API 스펙 완전 커버 (검색, 상세조회, 리스트)
- 5개 MCP 도구의 JSON Schema 정의
- CSV 파일 기반 카테고리 시스템 구축
- 타입 안전성과 런타임 검증 제공
- 캐싱 및 성능 최적화 고려

## 테스트 방법
```bash
# 타입 검사
pnpm type-check

# 프로젝트 빌드 (향후)
pnpm build
```

## 다음 단계
Task 2-1 (알라딘 API 클라이언트 구현) 및 Task 2-2 (유틸리티 모듈 구현)에서 이 타입들을 활용할 예정입니다.

🤖 Generated with [Claude Code](https://claude.ai/code)